### PR TITLE
Get empty cells when row values are zeroes, expect number zero cells

### DIFF
--- a/lib/components/ExcelFile.js
+++ b/lib/components/ExcelFile.js
@@ -41,7 +41,8 @@ class ExcelFile extends React.Component {
 
             React.Children.forEach(columns, column => {
                 const getValue = typeof (column.props.value) === 'function' ? column.props.value : row => row[column.props.value];
-                sheetRow.push(getValue(row) || '');
+                const itemValue = getValue(row);
+                sheetRow.push(isNaN(itemValue) ? (itemValue || '') : itemValue);
             });
 
             sheetData.push(sheetRow);


### PR DESCRIPTION
Fix the following issue: 

The _hotLevel_ column of the data is a column of number type, and many records will contains a zero value. The origin code will treat number zero as _undefined_ and return the empty string.

```
         <ExcelFile>
            <ExcelSheet data={this.props.data} name="list">
              <ExcelColumn label="ID" value="id" />
              <ExcelColumn label="hotelName" value="name" />
              <ExcelColumn label="hotLevel" value="hotLevel" />
            </ExcelSheet>
          </ExcelFile>
```