### PR TITLE
Added prop hideElement to hide or display download button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .idea/
 .nyc_output/
 coverage/
+dist/ExcelPlugin

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ npm install react-data-export --save
 
 ## Excel Props
 | Prop          | Type                 | Default    | Required | Description                      
-| :------------ | :------------------- | :--------- | :------- | :------------------------------- 
+| :------------ | :------------------- | :--------- | :------- | :-------------------------------------------------
+| hideElement	| `bool`			   | false      | `false`  | To hide the button & directly download excel file
 | filename      | `string`             | Download   | `false`  | Excel file name to be downloaded 
 | fileExtension | `string`             | xlsx       | `false`  | Download file extension [xlsx]
 | element       | `HTMLElement`        | `<button>` | `false`  | Element to download excel file
@@ -40,7 +41,7 @@ npm install react-data-export --save
 | dataSet       | `array<ExcelSheetData>` | `null`     | `false`  | Excel Sheet data
 | children      | `ExcelColumn`           |  `null`    | `false`  | ExcelColumns
 
-**Note:** In ExcelSheet props `dataSet` has `presedence` over `data` and `children` props.
+**Note:** In ExcelSheet props `dataSet` has `precedence` over `data` and `children` props.
 
 For further types and definitions [Read More](types/types.md)
 

--- a/src/ExcelPlugin/components/ExcelFile.js
+++ b/src/ExcelPlugin/components/ExcelFile.js
@@ -11,6 +11,7 @@ class ExcelFile extends React.Component {
     defaultFileExtension = 'xlsx';
 
     static  props = {
+        hideElement: PropTypes.bool,
         filename: PropTypes.string,
         fileExtension: PropTypes.string,
         element: PropTypes.any,
@@ -24,6 +25,7 @@ class ExcelFile extends React.Component {
     };
 
     static defaultProps = {
+        hideElement: false,
         filename: "Download",
         fileExtension: "xlsx",
         element: <button>Download</button>
@@ -32,7 +34,12 @@ class ExcelFile extends React.Component {
     constructor(props) {
         super(props);
 
-        this.handleDownload = this.download.bind(this);
+        if (this.props.hideElement) {
+            this.download();
+        } else {
+            this.handleDownload = this.download.bind(this);
+        }
+
         this.createSheetData = this.createSheetData.bind(this);
     }
 
@@ -107,7 +114,14 @@ class ExcelFile extends React.Component {
     }
 
     render() {
-        return (<span onClick={this.handleDownload}>{this.props.element}</span>);
+        const { hideElement, element } = this.props;
+
+        if (props.hideElement) {
+            return null;
+        } else {
+            return (<span onClick={this.handleDownload}>{element}</span>);
+        }
+        
     }
 }
 


### PR DESCRIPTION
By default the hideElement is set to false and will work as it is currently. If this prop is set to true, the download button doesn't show up on render, but will directly download the file.