### PR TITLE
Typescript definitions for components

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-data-export",
   "version": "0.5.0",
   "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "description": "A set of tools to export dataset from react to different formats.",
   "repository": {
     "type": "git",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,73 +1,75 @@
 /* index.d.ts (C) react-data-export */
 
 // TypeScript Version: 2.2
+declare module 'react-data-export' {
+  import * as React from 'react'
 
-export interface ExcelFileProps {
+  export interface ExcelFileProps {
     filename?: string;
     fileExtension?: string;
     element?: any; //Download Element
     children?: Array<ExcelSheetProps>;
-}
+  }
 
-export interface ExcelSheetProps {
+  export interface ExcelSheetProps {
     name: string;
     data?: Array<object>;
     dataSet?: Array<ExcelSheetData>;
     value?: Array<string> | Function;
     children?: Array<ExcelColumnProps>
-}
+  }
 
-export interface ExcelSheetData {
+  export interface ExcelSheetData {
     xSteps?: number;
     ySteps?: number;
     columns: Array<string>;
     data: Array<ExcelCellData>;
-}
+  }
 
-export type ExcelCellData = ExcelValue | ExcelCell;
-export type ExcelValue = string | number | Date | boolean;
+  export type ExcelCellData = ExcelValue | ExcelCell;
+  export type ExcelValue = string | number | Date | boolean;
 
-export interface ExcelCell {
+  export interface ExcelCell {
     value: ExcelCell;
     style: ExcelStyle;
-}
+  }
 
-export interface ExcelColumnProps {
+  export interface ExcelColumnProps {
     label: string;
     value: number | boolean | string | Function;
-}
+  }
 
-export interface ExcelStyle {
+  export interface ExcelStyle {
     fill?: ExcelCellFillType;
     font?: ExcelFont;
     numFmt?: ExcelNumFormat;
     alignment?: ExcelAlignment;
     border?: ExcelBorder;
-}
+  }
 
-/* ExcelCell Fill Type */
-export type ExcelCellPatternType = "solid" | "none";
+  /* ExcelCell Fill Type */
+  export type ExcelCellPatternType = "solid" | "none";
 
-export interface ExcelColorSpec {
+  export interface ExcelColorSpec {
     auto?: number; //default 1
     rgb?: string; //hex ARGB color
     theme?: ExcelTheme;
     indexed?: number;
-}
+  }
 
-export interface ExcelTheme {
+  export interface ExcelTheme {
     theme: string;
     tint: string;
-}
+  }
 
-export interface ExcelCellFillType {
+  export interface ExcelCellFillType {
     patternType?: ExcelCellPatternType;
     fgColor?: ExcelColorSpec;
     bgColor?: ExcelColorSpec;
-}
+  }
 
-/* Excel Font */
-export interface ExcelFont {
+  /* Excel Font */
+  export interface ExcelFont {
     name?: string;          // default `"Calibri"`
     sz?: number;             //font size in points default 11
     color?: ExcelColorSpec;
@@ -78,33 +80,33 @@ export interface ExcelFont {
     outline?: boolean;
     shadow?: boolean;
     vertAlign?: boolean;
-}
+  }
 
-/* ExcelNumFormat */
-export type ExcelNumFormat = "0" | "0.00%" | "0.0%" | "0.00%;\\(0.00%\\);\\-;@" | "m/dd/yy" | string;
+  /* ExcelNumFormat */
+  export type ExcelNumFormat = "0" | "0.00%" | "0.0%" | "0.00%;\\(0.00%\\);\\-;@" | "m/dd/yy" | string;
 
-/* ExcelAlignment */
-export interface ExcelAlignment {
+  /* ExcelAlignment */
+  export interface ExcelAlignment {
     vertical?: ExcelAlignmentType;
     horizontal?: ExcelAlignmentType;
     wrapText?: boolean;
     readingOrder?: ExcelReadingOrder;
     textRotation?: ExcelTextRotation;
-}
+  }
 
-export type ExcelTextRotation = 0 | 45 | 90 | 135 | 180 | 255;
+  export type ExcelTextRotation = 0 | 45 | 90 | 135 | 180 | 255;
 
-export enum ExcelReadingOrder { LeftToRight = 1, RightToLeft}
+  export enum ExcelReadingOrder { LeftToRight = 1, RightToLeft}
 
-export type ExcelAlignmentType = "bottom" | "center" | "top";
+  export type ExcelAlignmentType = "bottom" | "center" | "top";
 
-/* ExcelBorder */
-export interface ExcelBorder {
+  /* ExcelBorder */
+  export interface ExcelBorder {
     style: ExcelBorderStyle;
     color: ExcelColorSpec;
-}
+  }
 
-export type ExcelBorderStyle =
+  export type ExcelBorderStyle =
     "thin"
     | "medium"
     | "thick"
@@ -117,3 +119,19 @@ export type ExcelBorderStyle =
     | "dashDotDot"
     | "mediumDashDotDot"
     | "slantDashDot";
+
+  export class ExcelColumn extends React.Component<ExcelColumnProps, any> {
+  }
+
+  export class ExcelSheet extends React.Component<ExcelSheetProps, any> {
+  }
+
+  export class ExcelFile extends React.Component<ExcelFileProps, any> {
+  }
+
+  export namespace ReactExport {
+    export class ExcelFile extends React.Component<ExcelFileProps, any> {
+    }
+  }
+  export default ReactExport
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@ declare module 'react-data-export' {
     filename?: string;
     fileExtension?: string;
     element?: any; //Download Element
-    children?: Array<ExcelSheetProps>;
+    children?: Array<React.ReactChild> | React.ReactChild; // Array<ExcelSheetProps>;
   }
 
   export interface ExcelSheetProps {
@@ -16,7 +16,7 @@ declare module 'react-data-export' {
     data?: Array<object>;
     dataSet?: Array<ExcelSheetData>;
     value?: Array<string> | Function;
-    children?: Array<ExcelColumnProps>
+    children?: Array<React.ReactChild> | React.ReactChild; // Array<ExcelColumnProps>
   }
 
   export interface ExcelSheetData {
@@ -26,7 +26,7 @@ declare module 'react-data-export' {
     data: Array<ExcelCellData>;
   }
 
-  export type ExcelCellData = ExcelValue | ExcelCell;
+  export type ExcelCellData = ExcelValue | ExcelCell | Array<ExcelValue>;
   export type ExcelValue = string | number | Date | boolean;
 
   export interface ExcelCell {


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/securedeveloper/react-data-export/blob/master/CONTRIBUTING.md

  * If your PR fix an issue don't forget to update the unit test or add a new one
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Update examples whether is required
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature

-->
**Type:** TS types

The related issue is #64. I testet the declarations localy, but did not use them in a real project. Please check on additional examples that it works as expected and doesn't break anything for TS-users.

**Description:**
This PR introduces the types for the provided react components. The types are referenced in the package.json file. The following additional adoptions of the type declarations were made:
- children: as ReactChild and Array<ReactChild> (could not type it of a specific React.Component only)
- ExcelCellData with Array of ExcelValues to represent multidataset in ex2.

<!-- Resolves #??? -->
