### PR TITLE
bugfix: upgrade dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/securedeveloper/react-data-export#readme",
   "dependencies": {
-    "file-saver": "1.3.3",
-    "tempa-xlsx": "0.0.1"
+    "file-saver": "^2.0.2",
+    "tempa-xlsx": "^0.8.20"
   },
   "devDependencies": {
     "@commitlint/cli": "6.1.3",


### PR DESCRIPTION
**Type:** bug 
**Description:**

1. upgrade tempa-xlsx to 0.8.20 to fix the require warning as below. 

```
WARNING  Compiled with 1 warnings16:16:17

warning  in ./node_modules/react-data-export/node_modules/tempa-xlsx/ods.js

Module not found: Error: Can't resolve '../xlsx' in 'client\node_modules\react-data-export\node_modules\tempa-xlsx'
```

2. and upgrade file-saver to latest version.


