### PR TITLE
[feature] Added nested object key access for data and column match

### DIFF
--- a/dist/ExcelPlugin/components/ExcelFile.js
+++ b/dist/ExcelPlugin/components/ExcelFile.js
@@ -20,6 +20,10 @@ var _tempaXlsx = require("tempa-xlsx");
 
 var _tempaXlsx2 = _interopRequireDefault(_tempaXlsx);
 
+var _lodash = require("lodash");
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
 var _ExcelSheet = require("../elements/ExcelSheet");
 
 var _ExcelSheet2 = _interopRequireDefault(_ExcelSheet);
@@ -68,7 +72,7 @@ var ExcelFile = function (_React$Component) {
 
                 _react2.default.Children.forEach(columns, function (column) {
                     var getValue = typeof column.props.value === 'function' ? column.props.value : function (row) {
-                        return row[column.props.value];
+                        return _lodash2.default.get(row, column.props.value);
                     };
                     var itemValue = getValue(row);
                     sheetRow.push(isNaN(itemValue) ? itemValue || '' : itemValue);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "husky": "0.15.0-rc.13",
     "jest": "^23.6.0",
     "jest-environment-node": "22.4.1",
+    "lodash": "^4.17.21",
     "nyc": "11.2.1",
     "prop-types": "15.6.0",
     "react": "16.0.0",

--- a/src/ExcelPlugin/components/ExcelFile.js
+++ b/src/ExcelPlugin/components/ExcelFile.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import {saveAs} from "file-saver";
 import XLSX from "tempa-xlsx";
+import _ from 'lodash'; 
 
 import ExcelSheet from "../elements/ExcelSheet";
 import {strToArrBuffer, excelSheetFromAoA, excelSheetFromDataSet} from "../utils/DataUtil";
@@ -52,7 +53,7 @@ class ExcelFile extends React.Component {
             const sheetRow = [];
 
             React.Children.forEach(columns, column => {
-                const getValue = typeof (column.props.value) === 'function' ? column.props.value : row => row[column.props.value];
+                const getValue = typeof (column.props.value) === 'function' ? column.props.value : row => _.get(row, column.props.value);
                 const itemValue = getValue(row);
                 sheetRow.push(isNaN(itemValue) ? (itemValue || '') : itemValue);
             });


### PR DESCRIPTION
The following has been addressed in the PR:

*  There is a related  #164 

**Description:**

<!-- Resolves #??? -->

[feature] 

Accessing nested object is available with this PR

In the value prop of ExcelColumn, you can now provide nested object path  like "user.name" as in the example

```
const dataSet = [
  {
     user: {name: 'Mehmet', surname: 'Yılmaz'},
     period: 'Eylül - Ekim'
  },

  {
     user: {name: 'Semih', surname: 'Yavuz'},
     period: 'Haziran - Temmuz'
  }
]


class Download extends React.Component {
    render() {
        return (
            <ExcelFile>
                <ExcelSheet data={dataSet} name="Employees">
                    <ExcelColumn label="Name" value="user.name"/>
                    <ExcelColumn label="Period" value="period"/>
                </ExcelSheet>
            </ExcelFile>
        );
    }
}

```


