### PR TITLE
fix excelcell value in index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,7 +30,7 @@ declare module 'react-data-export' {
   export type ExcelValue = string | number | Date | boolean;
 
   export interface ExcelCell {
-    value: ExcelCell;
+    value: ExcelValue;
     style: ExcelStyle;
   }
 


### PR DESCRIPTION
The following has been addressed in the PR:
 
- Issue  #141 
- No unit tests added

**Description:**

Resolves issue #141, as it makes no sense ExcelCell to have the type ExcelCell itself. Instead, it should be ExcelValue. 


